### PR TITLE
make extra Re: optional in subject

### DIFF
--- a/src/CONTRIBUTORS
+++ b/src/CONTRIBUTORS
@@ -10,6 +10,7 @@
 * Guenter (neandr@github)
 * John Bieling (jobisoft@github)
 * Paolo Kaosmos
+* Daniela Grothe (DGrothe-PhD@github)
 
 
 ## Translators

--- a/src/_locales/de-DE/messages.json
+++ b/src/_locales/de-DE/messages.json
@@ -11,6 +11,9 @@
   "lang.localOnly": {
     "message": "Änderungen nur lokal speichern (Lokale Datenbank)"
   },
+   "lang.alwaysAddRePrefix": {
+    "message": "Bei Antworten immer Re: voranstellen"
+  },
   "lang.menuTitle": {
     "message": "E-Mail-Betreff bearbeiten"
   },

--- a/src/_locales/de-DE/messages.json
+++ b/src/_locales/de-DE/messages.json
@@ -1,6 +1,6 @@
 {
   "extensionDescription": {
-    "message": "Email Betreff bearbeiten"
+    "message": "E-Mail-Betreff bearbeiten"
   },
   "extensionName": {
     "message": "Edit email subject"
@@ -12,13 +12,13 @@
     "message": "Änderungen nur lokal speichern (Lokale Datenbank)"
   },
   "lang.menuTitle": {
-    "message": "Email Betreff bearbeiten"
+    "message": "E-Mail-Betreff bearbeiten"
   },
   "lang.subject": {
     "message": "Betreff:"
   },
   "lang.subjectOld": {
-    "message": "Original betreff:"
+    "message": "Original-Betreff:"
   },
   "lang.warning": {
     "message": "Warnung, der Betreff wurde schon bearbeitet. Eine erneute Änderung ist mit Risiken verbunden."

--- a/src/_locales/en-US/messages.json
+++ b/src/_locales/en-US/messages.json
@@ -11,6 +11,9 @@
   "lang.localOnly": {
     "message": "Only local changes (will only change local Thunderbird index database)"
   },
+  "lang.alwaysAddRePrefix": {
+    "message": "Always prepend Re: if e-mail is an answer"
+  },
   "lang.menuTitle": {
     "message": "Edit Mail Subject"
   },

--- a/src/_locales/fr-FR/messages.json
+++ b/src/_locales/fr-FR/messages.json
@@ -11,6 +11,9 @@
   "lang.localOnly": {
     "message": "Changements locaux uniquement (base de donnée locale de Thunderbird)"
   },
+  "lang.alwaysAddRePrefix": {
+    "message": "Toujours faire précéder les réponses de Re:."
+  },
   "lang.menuTitle": {
     "message": "Editer le sujet du message"
   },

--- a/src/_locales/hu/messages.json
+++ b/src/_locales/hu/messages.json
@@ -11,6 +11,9 @@
   "lang.localOnly": {
     "message": "Csak helyi változások (csak a helyi Thunderbird index adatbázis módosul)"
   },
+  "lang.alwaysAddRePrefix": {
+    "message": "Always prepend Re: if e-mail is an answer"
+  },
   "lang.menuTitle": {
     "message": "Tárgy szerkesztése"
   },

--- a/src/background.js
+++ b/src/background.js
@@ -3,7 +3,8 @@ async function main() {
   // define default prefs and migrate legacy settings
   let defaultPrefs = {
     "version": "2.1.1",
-    "localOnly": true
+    "localOnly": true,
+    "addRePrefix": true
   };
   await editEmailSubjectPreferences.setDefaults(defaultPrefs);
 

--- a/src/content/editemailsubject.js
+++ b/src/content/editemailsubject.js
@@ -35,6 +35,7 @@ var editEmailSubjectMain = {
   edit: async function (MessageHeader) {
     this.msg = {};
     this.msg.localMode = await editEmailSubjectPreferences.getPrefValue("localOnly");
+    this.msg.addReMode = await editEmailSubjectPreferences.getPrefValue("addRePrefix");
 
     if (MessageHeader) {
       this.msg.folder = MessageHeader.folder;
@@ -46,8 +47,9 @@ var editEmailSubjectMain = {
 
       let flags = await messenger.MessageModification.getMessageFlags(this.msg.id);
       //It looks like TB is storing a leading Re: not as part of the subject, but inside a flag, which is not honored by the subject member
-      if (flags & 0x0010) this.msg.subject = "Re: " + this.msg.subject;
-
+      if (this.msg.addReMode){
+        if (flags & 0x0010) this.msg.subject = "Re: " + this.msg.subject;
+      }
       // in remoteMode, if the header contains X-EditEmailSubject, we show a warning about being already modified
       if (!this.msg.localMode) {
         let full = await messenger.messages.getFull(this.msg.id);

--- a/src/content/options/options.html
+++ b/src/content/options/options.html
@@ -17,6 +17,11 @@
       <input type="checkbox" instantApply="true" preference="localOnly" />
       <div>__EESMSG_lang.localOnly__</div>
     </label>
+    <p></p>
+    <label>
+      <input type="checkbox" instantApply="true" preference="addRePrefix" />
+      <div>__EESMSG_lang.alwaysAddRePrefix__</div>
+    </label>
   </div>
 </body>
 


### PR DESCRIPTION
An extra checkbox is added to the preferences, set true by default.
When option set to false, no extra "Re:" is added to the email subject. Tested with TB 102.6.1.
Label text added in all translation files except for Hungarian wherein label text is English.
Addressed https://github.com/cleidigh/EditEmailSubject-MX/issues/43